### PR TITLE
chore: updated readme, adjusted SSL protocols and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,54 +2,34 @@
 
 Build script and patches for nginx reverse proxy for use with production-grade Plex CDNs.
 
-
 ## Features
 
-```
-nginx version: nginx/1.23.4 (15042023-093836-UTC-[debian_nginx-quic+quictls])
-built by gcc 12.2.0 (GCC)
-built with OpenSSL 3.1.0+quic 14 Mar 2023
-TLS SNI support enabled
-configure arguments: --build=15042023-093836-UTC-[debian_nginx-quic+quictls] --prefix=/etc/nginx --with-cpu-opt=generic --with-cc-opt='-I/usr/local/include -pipe -m64 -march=native -DTCP_FASTOPEN=23 -falign-functions=32 -O3 -Wno-error=strict-aliasing -Wno-vla-parameter -fstack-protector-strong -fuse-ld=mold --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wno-error=pointer-sign -Wimplicit-fallthrough=0 -fcode-hoisting -Wp,-D_FORTIFY_SOURCE=2 -Wno-deprecated-declarations' --with-ld-opt='-Wl,-E -L/usr/local/lib -ljemalloc -Wl,-z,relro -Wl,-rpath,/usr/local/lib -fuse-ld=mold' --with-openssl=../openssl-3.1.0+quic --with-openssl-opt='-pipe -O3 -fPIC -m64 -march=native -ljemalloc -fstack-protector-strong -D_FORTIFY_SOURCE=2 -Wl,-flto=16 no-weak-ssl-ciphers no-ssl3 no-idea no-err no-srp no-psk no-nextprotoneg enable-ktls enable-zlib enable-ec_nistp_64_gcc_128' --with-zlib=../zlib-cloudflare --with-zlib-opt='-pipe -O3 -fPIC -m64 -march=native -ljemalloc -fstack-protector-strong -D_FORTIFY_SOURCE=2 -flto=16' --with-pcre=../pcre-8.45 --with-pcre-opt='-pipe -O3 -fPIC -m64 -march=native -ljemalloc -fstack-protector-strong -D_FORTIFY_SOURCE=2 -flto=16' --with-libatomic=../libatomic_ops-7.8.0 --conf-path=/etc/nginx/nginx.conf --error-log-path=/var/log/nginx/error.log --http-log-path=/var/log/nginx/access.log --lock-path=/var/run/nginx.lock --modules-path=/usr/lib/nginx/modules --pid-path=/var/run/nginx.pid --sbin-path=/usr/sbin/nginx --http-client-body-temp-path=/var/cache/nginx/client_temp --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp --http-proxy-temp-path=/var/cache/nginx/proxy_temp --http-scgi-temp-path=/var/cache/nginx/scgi_temp --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp --user=nginx --group=nginx --with-file-aio --with-threads --with-http_realip_module --with-http_ssl_module --with-http_v2_hpack_enc --with-http_v2_module --with-http_v3_module --add-module=../ngx_security_headers-0.0.11 --without-http_access_module --without-http_auth_basic_module --without-http_autoindex_module --without-http_browser_module --without-http_charset_module --without-http_empty_gif_module --without-http_fastcgi_module --without-http_geo_module --without-http_grpc_module --without-http_limit_conn_module --without-http_limit_req_module --without-http_memcached_module --without-http_mirror_module --without-http_referer_module --without-http_scgi_module --without-http_split_clients_module --without-http_ssi_module --without-http_upstream_hash_module --without-http_upstream_ip_hash_module --without-http_upstream_least_conn_module --without-http_upstream_random_module --without-http_upstream_zone_module --without-http_userid_module --without-http_uwsgi_module --without-mail_imap_module --without-mail_pop3_module --without-mail_smtp_module --without-poll_module --without-select_module --without-pcre2
-```
-
-* nginx-quic 1.23.4 - https://hg.nginx.org/nginx-quic
-* openssl-3.1.0+quic - quictls: https://github.com/quictls/openssl
-* Kernel TLS - https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls
-* QUIC transport protocol and HTTP/3 - https://www.nginx.com/blog/introducing-technology-preview-nginx-support-for-quic-http-3/
-* Add HTTP2 HPACK Encoding Support - https://blog.cloudflare.com/hpack-the-silent-killer-feature-of-http-2/
-* Add Dynamic TLS Record support - https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/
-* ngx_security_headers - https://github.com/GetPageSpeed/ngx_security_headers
-* CloudFlare ZLIB - https://github.com/cloudflare/zlib
+* [nginx-quic 1.23.4](https://hg.nginx.org/nginx-quic)
+* [openssl-3.1.0+quic - quictls](https://github.com/quictls/openssl)
+* [Kernel TLS](https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls)
+* [QUIC transport protocol and HTTP/3](https://www.nginx.com/blog/introducing-technology-preview-nginx-support-for-quic-http-3/)
+* [HTTP2 HPACK encoding support](https://blog.cloudflare.com/hpack-the-silent-killer-feature-of-http-2/)
+* [Dynamic TLS Record support](https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/)
+* [ngx_security_headers](https://github.com/GetPageSpeed/ngx_security_headers)
+* [Cloudflare zlib](https://github.com/cloudflare/zlib)
 * Prevents public access to PMS built-in web interface
-* tmpfs cache for Plex images & metadata
- 
+* [tmpfs](https://en.wikipedia.org/wiki/Tmpfs) cache for Plex images & metadata
+
 ## Requirements
- 
-Plex:
+* [Debian 11+](https://www.debian.org/) or [Ubuntu 20+](https://ubuntu.com/)
+* [Kernel with TLS module enabled (CONFIG_TLS=y)](https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls)
+* [gcc (12.2.0)](https://gcc.gnu.org/)
+* [mold linker (1.11.0)](https://github.com/rui314/mold)
+
+## Plex Configuration
 * Remote Access - Disable
 * Network - Relay - Disable
 * Network - Custom server access URLs = `https://<your-domain>:443,http://<your-domain>:80`
 * Network - Secure connections = Preferred
 
-System: 
-* Debian Bullseye x64 (11)
-* Kernel with TLS module enabled (CONFIG_TLS=y) - https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls
-* gcc (12.2.0)
-* mold linker (1.11.0) - https://github.com/rui314/mold
 
-```
-Using built-in specs.
-COLLECT_GCC=gcc
-COLLECT_LTO_WRAPPER=/usr/local/gcc-12.2.0/libexec/gcc/x86_64-linux-gnu/12.2.0/lto-wrapper
-Target: x86_64-linux-gnu
-Configured with: ../gcc-12.2.0/configure -v --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu --prefix=/usr/local/gcc-12.2.0 --enable-checking=release --enable-languages=c,c++ --disable-multilib --program-suffix=-12.2 --with-system-zlib --with-cc-opt='-ljemalloc -fuse-ld=mold'
-Thread model: posix
-Supported LTO compression algorithms: zlib
-gcc version 12.2.0 (GCC)
-```
 
-Credits:
+## Credits:
  * Originally based on https://github.com/toomuchio/plex-nginx-reverseproxy
  * Build script based on https://github.com/MatthewVance/nginx-build
- * Forked based on https://codeberg.org/0x0f/plex-nginx-reverseproxy-cf
+ * Current fork based on https://codeberg.org/0x0f/plex-nginx-reverseproxy-cf

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-This configuration will allow you to serve PMS via nginx behind CloudFlare
+# plex-nginx-rp
 
- * Originally based on https://github.com/toomuchio/plex-nginx-reverseproxy
- * Build script based on https://github.com/MatthewVance/nginx-build
+Build script and patches for nginx reverse proxy for use with production-grade Plex CDNs.
+
 
 ## Features
 
@@ -49,24 +49,7 @@ Supported LTO compression algorithms: zlib
 gcc version 12.2.0 (GCC)
 ```
 
-```
-String dump of section '.comment':
-  [     0]  mold 1.11.0 (cca255e6be069cdbc135c83fd16036d86b98b85e; compatible with GNU ld)
-  [    4f]  GCC: (GNU) 12.2.0
-```
-
-Cloudflare:
-* SSL: https://support.cloudflare.com/hc/en-us/categories/200276247-SSL-TLS
-
-iptables:
-* Deny port 32400 externally (Plex still pings over 32400, some clients may use 32400 by mistake despite 443 and 80 being set)
-* Note adding `allowLocalhostOnly="1"` to your Preferences.xml, will make Plex only listen on the localhost, achieving the same thing as using a firewall
-* Only allow CloudFlare IPs via iptables using ipset
-
-```
-ipset create cf hash:net
-for x in $(curl https://www.cloudflare.com/ips-v4); do ipset add cf $x; done
-iptables -A INPUT -p tcp -m tcp --dport 32400 -j DROP
-iptables -A INPUT -m set --match-set cf src -p tcp -m multiport --dports http,https -j ACCEPT
-iptables -A INPUT -m set --match-set cf src -p udp -m multiport --dports https -j ACCEPT
-```
+Credits:
+ * Originally based on https://github.com/toomuchio/plex-nginx-reverseproxy
+ * Build script based on https://github.com/MatthewVance/nginx-build
+ * Forked based on https://codeberg.org/0x0f/plex-nginx-reverseproxy-cf

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Build script and patches for nginx reverse proxy for use with production-grade Plex CDNs.
 
 ## Features
-
 * [nginx-quic 1.23.4](https://hg.nginx.org/nginx-quic)
 * [openssl-3.1.0+quic - quictls](https://github.com/quictls/openssl)
 * [Kernel TLS](https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls)
@@ -24,10 +23,8 @@ Build script and patches for nginx reverse proxy for use with production-grade P
 ## Plex Configuration
 * Remote Access - Disable
 * Network - Relay - Disable
-* Network - Custom server access URLs = `https://<your-domain>:443,http://<your-domain>:80`
+* Network - Custom server access URLs = `https://cdn.plex.your-domain.tld:443`
 * Network - Secure connections = Preferred
-
-
 
 ## Credits:
  * Originally based on https://github.com/toomuchio/plex-nginx-reverseproxy

--- a/build-nginx.sh
+++ b/build-nginx.sh
@@ -95,17 +95,17 @@ fi
 
 ## We add sites-* folders as some use them. /etc/nginx/conf.d/ is the vhost folder by defaultnginx
 if [[ ! -d /etc/nginx/sites-available ]]; then
-	mkdir -p /etc/nginx/sites-available
-	cp "$SPATH/conf/plex.domain.tld" "/etc/nginx/sites-available/plex.domain.tld"
+  mkdir -p /etc/nginx/sites-available
+  cp "$SPATH/conf/plex.domain.tld" "/etc/nginx/sites-available/plex.domain.tld"
 fi
 if [[ ! -d /etc/nginx/sites-enabled ]]; then
-	mkdir -p /etc/nginx/sites-enabled
+  mkdir -p /etc/nginx/sites-enabled
 fi
 
 if [[ ! -e /etc/nginx/nginx.conf ]]; then
-	mkdir -p /etc/nginx
-	cd /etc/nginx || exit 1
-	cp "$SPATH/conf/nginx.conf" "/etc/nginx/nginx.conf"
+  mkdir -p /etc/nginx
+  cd /etc/nginx || exit 1
+  cp "$SPATH/conf/nginx.conf" "/etc/nginx/nginx.conf"
 fi
 
 ## Add NGINX group and user if they do not already exist
@@ -143,8 +143,8 @@ cd "$BPATH/nginx-quic"
 
 patch -p1 < "$SPATH/patches/https2_hpack+dynamic_tls.patch"
 
+# You may need to adjust the --with and --without for your specific use case.
 ./auto/configure \
-  --build="$TIME-[debian_nginx-quic+quictls]" \
   --prefix=/etc/nginx \
   --with-cpu-opt=generic \
   --with-cc-opt='-I/usr/local/include -pipe -m64 -march=native -DTCP_FASTOPEN=23 -falign-functions=32 -O3 -Wno-error=strict-aliasing -Wno-vla-parameter -fstack-protector-strong -fuse-ld=mold --param=ssp-buffer-size=4 -Wformat -Werror=format-security -Wno-error=pointer-sign -Wimplicit-fallthrough=0 -fcode-hoisting -Wp,-D_FORTIFY_SOURCE=2 -Wno-deprecated-declarations' \
@@ -178,29 +178,12 @@ patch -p1 < "$SPATH/patches/https2_hpack+dynamic_tls.patch"
   --with-http_v2_module \
   --with-http_v3_module \
   --add-module="../ngx_security_headers-$VERSION_SECURITY_HEADERS" \
-  --without-http_access_module \
-  --without-http_auth_basic_module \
-  --without-http_autoindex_module \
-  --without-http_browser_module \
-  --without-http_charset_module \
-  --without-http_empty_gif_module \
-  --without-http_fastcgi_module \
-  --without-http_geo_module \
   --without-http_grpc_module \
-  --without-http_limit_conn_module \
-  --without-http_limit_req_module \
   --without-http_memcached_module \
   --without-http_mirror_module \
-  --without-http_referer_module \
   --without-http_scgi_module \
   --without-http_split_clients_module \
   --without-http_ssi_module \
-  --without-http_upstream_hash_module \
-  --without-http_upstream_ip_hash_module \
-  --without-http_upstream_least_conn_module \
-  --without-http_upstream_random_module \
-  --without-http_upstream_zone_module \
-  --without-http_userid_module \
   --without-http_uwsgi_module \
   --without-mail_imap_module \
   --without-mail_pop3_module \

--- a/conf/plex.domain.tld
+++ b/conf/plex.domain.tld
@@ -98,7 +98,7 @@ server {
 	ssl_verify_client on;
 
 	## https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls/
-	ssl_protocols TLSv1.3;
+	ssl_protocols TLSv1.3 TLSv1.2;
 	ssl_conf_command Options KTLS;
 	ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384; # KTLS compatible TLSv1.3 cipher
 	ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384; # KTLS compatible TLSv1.3 cipher
@@ -112,7 +112,7 @@ server {
 
 	## Nginx default client_max_body_size is 1MB, which breaks Camera Upload feature from the phones
 	## Increasing the limit fixes the issue. Anyhow, if 4K videos are expected to be uploaded, the size might need to be increased even more
-	client_max_body_size 256M;
+	client_max_body_size 512M;
 
 	## Compression
 	gzip on;


### PR DESCRIPTION
- TLSv1.2 is now allowed alongside v1.3 for backwards compatibility with older devices.
- we still need to update the ciphers so that older iOS stuff functions with it. believe we used aes-128 in the past?
- increased max_body_size from 256M to 512M because we're not running through cloudflare anyways so we can adjust this freely.
- various cleanup on the README.