### PR TITLE
chore: updated readme, adjusted SSL protocols and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Build script and patches for nginx reverse proxy for use with production-grade Plex CDNs.
 
+
 ## Features
 * [nginx-quic (1.23.4)](https://hg.nginx.org/nginx-quic)
 * [OpenSSL-quic (3.1.0)](https://github.com/quictls/openssl)

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,45 +1,45 @@
 pid /run/nginx.pid;
 
-## Set user nginx should run under
+# Set user nginx should run under
 user www-data;
 
-## You must set worker processes based on your CPU cores, nginx does not benefit from setting more than that
+# You must set worker processes based on your CPU cores, nginx does not benefit from setting more than that
 worker_cpu_affinity auto;
 worker_priority -10;
 worker_processes auto;
 
-## Number of file descriptors used for nginx
-## The limit for the maximum FDs on the server is usually set by the OS
-## If you don't set FD's then OS settings will be used which is by default 2000
+# Number of file descriptors used for nginx
+# The limit for the maximum FDs on the server is usually set by the OS
+# If you don't set FD's then OS settings will be used which is by default 2000
 worker_rlimit_nofile 520000;
 
-## Reduces timer resolution in worker processes, thus reducing the number of gettimeofday() system calls made.
+# Reduces timer resolution in worker processes, thus reducing the number of gettimeofday() system calls made.
 timer_resolution 100ms;
 
-## Enables routing of QUIC packets using eBPF. When enabled, this allows to support QUIC connection migration. The directive is only supported on Linux 5.7+.
+# Enables routing of QUIC packets using eBPF. When enabled, this allows to support QUIC connection migration. The directive is only supported on Linux 5.7+.
 quic_bpf on;
 
-## Only log critical errors
+# Only log critical errors
 error_log /var/log/nginx/error.log crit;
 
 events {
-	## Determines how much clients will be served per worker
-	## max clients = worker_connections * worker_processes
-	## max clients is also limited by the number of socket connections available on the system (~64k)
+	# Determines how much clients will be served per worker
+	# max clients = worker_connections * worker_processes
+	# max clients is also limited by the number of socket connections available on the system (~64k)
 	worker_connections 100000;
 
-	## There is no need to enable accept_mutex on systems that support the EPOLLEXCLUSIVE flag (1.11.3) or when using reuseport.
+	# There is no need to enable accept_mutex on systems that support the EPOLLEXCLUSIVE flag (1.11.3) or when using reuseport.
 	accept_mutex off;
 
-	## Optimized to serve many clients with each thread, essential for linux
+	# Optimized to serve many clients with each thread, essential for linux
 	use epoll;
 
-	## Accept as many connections as possible
+	# Accept as many connections as possible
 	multi_accept on;
 }
 
 http {
-	## If a large number of server names are defined, or unusually long server names are defined, tuning may become necessary
+	# If a large number of server names are defined, or unusually long server names are defined, tuning may become necessary
 	map_hash_bucket_size 128;
 	map_hash_max_size 4096;
 	server_name_in_redirect off;
@@ -48,40 +48,40 @@ http {
 	variables_hash_max_size 2048;
 
 
-	## Cache informations about FDs, frequently accessed files
-	## Can boost performance, but you need to test those values
+	# Cache informations about FDs, frequently accessed files
+	# Can boost performance, but you need to test those values
 	open_file_cache max=50000 inactive=60s;
 	open_file_cache_errors off;
 	open_file_cache_min_uses 2;
 	open_file_cache_valid 120s;
 	open_log_file_cache max=10000 inactive=30s min_uses=2;
 
-	## Enables multi-threading
+	# Enables multi-threading
 	aio threads;
 	aio_write on;
 
-	## To boost I/O on HDD we can disable access logs
+	# To boost I/O on HDD we can disable access logs
 	access_log off;
 	log_not_found off;
 
-	## https://github.com/GetPageSpeed/ngx_security_headers
+	# https://github.com/GetPageSpeed/ngx_security_headers
 	hide_server_tokens on;
 	ignore_invalid_headers on;
 	security_headers off;
 
-	## Combining kTLS and sendfile() means data is encrypted directly in kernel space, before being passed to the network stack for transmission
+	# Combining kTLS and sendfile() means data is encrypted directly in kernel space, before being passed to the network stack for transmission
 	sendfile on;
 
-	## Send headers in one piece, it is better than sending them one by one
+	# Send headers in one piece, it is better than sending them one by one
 	tcp_nopush on;
 
-	## Don't buffer data sent, good for small data bursts in real time
+	# Don't buffer data sent, good for small data bursts in real time
 	tcp_nodelay on;
 
-	## Allow the server to close connection on non responding client, this will free up memory
+	# Allow the server to close connection on non responding client, this will free up memory
 	reset_timedout_connection on;
 
-	## Timeouts really improve nginx performance substantially. The keepalive connections reduce cpu and network overhead required for opening and closing connections
+	# Timeouts really improve nginx performance substantially. The keepalive connections reduce cpu and network overhead required for opening and closing connections
 	client_body_timeout 30s;
 	client_header_timeout 30s;
 	keepalive_disable msie6;
@@ -92,7 +92,7 @@ http {
 	reset_timedout_connection on;
 	send_timeout 60s;
 
-	## Buffers play a big role in the optimization of nginx performance. The following are the variables that need to be adjusted for optimum performance
+	# Buffers play a big role in the optimization of nginx performance. The following are the variables that need to be adjusted for optimum performance
 	client_body_buffer_size 64k;
 	client_header_buffer_size 64k;
 	client_max_body_size 1024m;
@@ -104,10 +104,10 @@ http {
 	postpone_output 1460;
 	request_pool_size 32k;
 
-	## MIME
+	# MIME
 	default_type application/octet-stream;
 	include mime.types;
 
-	## Load configs
+	# Load configs
 	include /etc/nginx/sites-enabled/*;
 }

--- a/conf/plex.domain.tld
+++ b/conf/plex.domain.tld
@@ -1,16 +1,18 @@
-## Must be set in the global scope see: https://forum.nginx.org/read.php?2,152294,152294
-## Why this is important especially with Plex as it makes a lot of requests http://vincent.bernat.im/en/blog/2011-ssl-session-reuse-rfc5077.html / https://www.peterbe.com/plog/ssl_session_cache-ab
-## https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&guideline=5.6
+# Must be set in the global scope see: 
+# https://forum.nginx.org/read.php?2,152294,152294
+# Why this is important especially with Plex as it makes a lot of requests:
+# http://vincent.bernat.im/en/blog/2011-ssl-session-reuse-rfc5077.html
+# https://www.peterbe.com/plog/ssl_session_cache-ab
+# https://ssl-config.mozilla.org/#server=nginx&version=1.17.7&config=intermediate&openssl=1.1.1k&guideline=5.6
 ssl_session_cache shared:MozSSL:10m;
 ssl_session_timeout 1d;
 ssl_session_tickets off;
 
-## Cache for plex images & metadata (purges files older than 7d or goes over capacity; adjust these values below to suit)
+# Cache for plex images & metadata (purges files older than 7d or goes over capacity; adjust these values below to suit)
 proxy_cache_path /tmp/nginx-images levels=1:2 keys_zone=plex-images:10m inactive=7d max_size=4096M min_free=50M;
 proxy_cache_path /tmp/nginx-metadata levels=1:2 keys_zone=plex-metadata:10m inactive=7d max_size=1024M min_free=50M;
 
-## https://old.reddit.com/r/PleX/comments/12gwoio/plex_nginx_reverse_proxy_caching/
-
+# https://old.reddit.com/r/PleX/comments/12gwoio/plex_nginx_reverse_proxy_caching/
 map $args $x_plex_client_identifier {
 	"~(^|&)X-Plex-Client-Identifier=(?<temp>[^&]+)" $temp;
 }
@@ -35,32 +37,22 @@ map $args $url {
 	"~(^|&)url=(?<temp>[^&]+)" $temp;
 }
 
-## Upstream to PMS
+# Upstream to PMS
 upstream plex_backend {
 	server 127.0.0.1:32400;
 	keepalive 32;
 }
 
-## Redirect http to https
 server {
-	## SO_REUSEPORT can reduce lock contention between workers accepting new connections, and improve performance on multicore systems.
-	## TCP_DEFER_ACCEPT can help boost performance by reducing the amount of preliminary formalities that happen between the server and client.
-	listen 80 reuseport deferred;
-	server_name plex.domain.tld;
-	return 301 https://$host$request_uri;
-}
-
-server {
-	## http2 can provide a substantial improvement for streaming: https://blog.cloudflare.com/introducing-http2/
-	## SO_REUSEPORT can reduce lock contention between workers accepting new connections, and improve performance on multicore systems.
-	## TCP_DEFER_ACCEPT can help boost performance by reducing the amount of preliminary formalities that happen between the server and client.
+	# SO_REUSEPORT can reduce lock contention between workers accepting new connections, and improve performance on multicore systems.
+	# TCP_DEFER_ACCEPT can help boost performance by reducing the amount of preliminary formalities that happen between the server and client.
 	listen 443 ssl http2 reuseport deferred;
-	## https://www.nginx.com/blog/introducing-technology-preview-nginx-support-for-quic-http-3/
+	# https://www.nginx.com/blog/introducing-technology-preview-nginx-support-for-quic-http-3/
 	listen 443 http3 reuseport;
 	server_name plex.domain.tld;
 
-	## http://nginx.org/en/docs/http/ngx_http_v2_module.html
-	## https://quic.nginx.org/readme.html
+	# http://nginx.org/en/docs/http/ngx_http_v2_module.html
+	# https://quic.nginx.org/readme.html
 	http2_push_preload on;
 	http3_max_concurrent_pushes 30;
 	http3_max_concurrent_streams 256;
@@ -77,19 +69,19 @@ server {
 	proxy_buffers 32 4k;
 	proxy_headers_hash_bucket_size 128;
 	proxy_headers_hash_max_size 1024;
-	send_timeout 100m; ## Some players don't reopen a socket and playback stops totally instead of resuming after an extended pause (e.g. Chrome)
+	send_timeout 100m; # Some players don't reopen a socket and playback stops totally instead of resuming after an extended pause (e.g. Chrome)
 
-	ssl_early_data on; ## Enable TLSv1.3's 0-RTT. Use $ssl_early_data when reverse proxying to prevent replay attacks - http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data
-	ssl_dyn_rec_enable on; ## https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/
-	ssl_buffer_size 4k; ## https://haydenjames.io/nginx-tuning-tips-tls-ssl-https-ttfb-latency/
+	ssl_early_data on; # Enable TLSv1.3's 0-RTT. Use $ssl_early_data when reverse proxying to prevent replay attacks - http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_early_data
+	ssl_dyn_rec_enable on; # https://blog.cloudflare.com/optimizing-tls-over-tcp-to-reduce-latency/
+	ssl_buffer_size 4k; # https://haydenjames.io/nginx-tuning-tips-tls-ssl-https-ttfb-latency/
 
-	## fetch OCSP records from URL in ssl_certificate and cache them
-	resolver 127.0.0.1 1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 ipv6=off valid=60s;
+	# fetch OCSP records from URL in ssl_certificate and cache them
+	resolver 127.0.0.1 9.9.9.9 149.112.112.112 ipv6=off valid=60s;
 	resolver_timeout 5s;
 	ssl_stapling on;
 	ssl_stapling_verify on;
 
-	## https://support.cloudflare.com/hc/en-us/categories/200276247-SSL-TLS
+	# https://support.cloudflare.com/hc/en-us/categories/200276247-SSL-TLS
 	ssl_certificate /etc/nginx/ssl/domain.tld/cert.pem;
 	ssl_certificate_key /etc/nginx/ssl/domain.tld/key.pem;
 	ssl_client_certificate /etc/nginx/ssl/domain.tld/cf.pem;
@@ -97,8 +89,8 @@ server {
 	ssl_dhparam /etc/nginx/ssl/dhparam.pem; # Generate: dhparam -out /etc/nginx/ssl/dhparam.pem 4096
 	ssl_verify_client on;
 
-	## https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls/
-	ssl_protocols TLSv1.3 TLSv1.2;
+	# https://www.nginx.com/blog/improving-nginx-performance-with-kernel-tls/
+	ssl_protocols TLSv1.3;
 	ssl_conf_command Options KTLS;
 	ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384; # KTLS compatible TLSv1.3 cipher
 	ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384; # KTLS compatible TLSv1.3 cipher
@@ -110,29 +102,29 @@ server {
 		return '405';
 	}
 
-	## Nginx default client_max_body_size is 1MB, which breaks Camera Upload feature from the phones
-	## Increasing the limit fixes the issue. Anyhow, if 4K videos are expected to be uploaded, the size might need to be increased even more
+	# Nginx default client_max_body_size is 1MB, which breaks Camera Upload feature from the phones
+	# Increasing the limit fixes the issue. Anyhow, if 4K videos are expected to be uploaded, the size might need to be increased even more
 	client_max_body_size 512M;
 
-	## Compression
+	# Compression
 	gzip on;
 	gzip_proxied any;
 	gzip_comp_level 6;
 	gzip_min_length 20;
 	gzip_http_version 1.1;
-	## https://support.cloudflare.com/hc/en-us/articles/200168396-What-will-Cloudflare-compress-
+	# https://support.cloudflare.com/hc/en-us/articles/200168396-What-will-Cloudflare-compress-
 	gzip_types application/atom+xml application/geo+json application/javascript application/json application/ld+json application/manifest+json application/rdf+xml application/rss+xml application/vnd.ms-fontobject application/wasm application/x-perl application/x-web-app-manifest+json application/xhtml+xml application/xml application/xspf+xml audio/midi font/otf image/bmp image/svg+xml text/cache-manifest text/calendar text/css text/javascript text/markdown text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy text/xml;
 
-	## HTTP3/QUIC
-	add_header Alt-Svc 'h3=":443"; ma=86400'; ## Advertise that QUIC is available
-	add_header X-Early-Data $tls1_3_early_data; ## 0-RTT
+	# HTTP3/QUIC
+	add_header Alt-Svc 'h3=":443"; ma=86400'; # Advertise that QUIC is available
+	add_header X-Early-Data $tls1_3_early_data; # 0-RTT
 
-	## Generated via: https://forums.plex.tv/t/guide-howto-reverse-proxy-header-hardening-csp-security-headers/676189
+	# Generated via: https://forums.plex.tv/t/guide-howto-reverse-proxy-header-hardening-csp-security-headers/676189
 	set $script_hashes "'sha256-jeftGV7LmTJr5Kd2dJKcMDmTwNuXMyL6wKQaB39fF+U=' 'sha256-pKO/nNgeauDINvYfxdygP3mGssdVQRpRNxaF7uPRoGM=' 'sha256-yzewNIK88H9e/nnbvcRDaRitv6LXSahLCAXIFAjaetU='";
 	set $style_hashes "'sha256-ZdHxw9eWtnxUb3mk6tBS+gIiVUPE3pGM470keHPDFlE='";
 
-	## https://github.com/GetPageSpeed/ngx_security_headers
-	## https://securityheaders.com & https://csp-evaluator.withgoogle.com
+	# https://github.com/GetPageSpeed/ngx_security_headers
+	# https://securityheaders.com & https://csp-evaluator.withgoogle.com
 	add_header Referrer-Policy "same-origin" always;
 	add_header Strict-Transport-Security "max-age=63072000; includesubdomains; preload" always;
 	add_header X-Content-Type-Options "nosniff" always;
@@ -147,31 +139,6 @@ server {
 	add_header Cross-Origin-Resource-Policy same-site;
 	add_header X-Robots-Tag "noindex, noarchive, nosnippet";
 
-	## Restoring original visitor IPs: https://support.cloudflare.com/hc/en-us/articles/200170786-Restoring-original-visitor-IPs-logging-visitor-IP-addresses
-	set_real_ip_from 103.21.244.0/22;
-	set_real_ip_from 103.22.200.0/22;
-	set_real_ip_from 103.31.4.0/22;
-	set_real_ip_from 104.16.0.0/12;
-	set_real_ip_from 104.24.0.0/14;
-	set_real_ip_from 108.162.192.0/18;
-	set_real_ip_from 131.0.72.0/22;
-	set_real_ip_from 141.101.64.0/18;
-	set_real_ip_from 162.158.0.0/15;
-	set_real_ip_from 172.64.0.0/13;
-	set_real_ip_from 173.245.48.0/20;
-	set_real_ip_from 188.114.96.0/20;
-	set_real_ip_from 190.93.240.0/20;
-	set_real_ip_from 197.234.240.0/22;
-	set_real_ip_from 198.41.128.0/17;
-	set_real_ip_from 2400:cb00::/32;
-	set_real_ip_from 2606:4700::/32;
-	set_real_ip_from 2803:f800::/32;
-	set_real_ip_from 2405:b500::/32;
-	set_real_ip_from 2405:8100::/32;
-	set_real_ip_from 2c0f:f248::/32;
-	set_real_ip_from 2a06:98c0::/29;
-	real_ip_header X-Forwarded-For;
-
 	proxy_pass_request_headers on;
 
 	proxy_set_header Host $host;
@@ -180,7 +147,7 @@ server {
 	proxy_set_header X-Forwarded-Proto $scheme;
 	proxy_set_header X-Forwarded-Ssl on;
 
-	## Headers required for PMS
+	# Headers required for PMS
 	proxy_set_header X-Plex-Client-Identifier $http_x_plex_client_identifier;
 	proxy_set_header X-Plex-Container-Size $http_x_plex_container_size;
 	proxy_set_header X-Plex-Container-Start $http_x_plex_container_start;
@@ -196,7 +163,7 @@ server {
 	proxy_set_header X-Plex-Device-Vendor $http_x_plex_device_vendor;
 	proxy_set_header X-Plex-Model $http_x_plex_model;
 
-	## Enable websockets
+	# Enable websockets
 	proxy_set_header Sec-WebSocket-Extensions $http_sec_websocket_extensions;
 	proxy_set_header Sec-WebSocket-Key $http_sec_websocket_key;
 	proxy_set_header Sec-WebSocket-Version $http_sec_websocket_version;
@@ -209,20 +176,16 @@ server {
 	proxy_read_timeout 86400;
 	proxy_redirect off;
 
-	## Disables compression between PMS and Nginx which improves latency. Enabling may improve throughput, but at the cost of increased latency.
+	# Disables compression between PMS and Nginx which improves latency. Enabling may improve throughput, but at the cost of increased latency.
 	proxy_buffering off;
 	proxy_request_buffering off;
 
-	## Redirect errors to domain
-	proxy_intercept_errors on;
-	error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =301 https://domain.tld;
-
-	## Reverse proxy to PMS
+	# Reverse proxy to PMS
 	location / {
 		proxy_pass http://plex_backend;
 	}
 
-	## https://old.reddit.com/r/PleX/comments/12gwoio/plex_nginx_reverse_proxy_caching/
+	# https://old.reddit.com/r/PleX/comments/12gwoio/plex_nginx_reverse_proxy_caching/
 	location /photo/:/transcode {
 		add_header X-Cache-Date $upstream_http_date;
 		add_header X-Cache-Status $upstream_cache_status;
@@ -352,14 +315,9 @@ server {
 		proxy_ssl_verify off;
 		sendfile on;
 	}
-
-	## Redirects PMS webserver to domain
-	location /web/ {
-		return 301 https://domain.tld;
-	}
 }
 
-## 0-RTT
+# 0-RTT
 map $ssl_early_data $tls1_3_early_data {
 	"~." $ssl_early_data;
 	default "";


### PR DESCRIPTION
- comments now use one # instead of ## for nginx configs because we're not psychopaths.
- removed http listener because we're not listening on :80 anyways.
- removed google DNS from SSL stapling. added quad9 so fallback is now 127.0.0.1 > quad9 > cloudflare.
- temporarily rolling back TLSv1.2 so legacy iOS will be ded until we find the old ciphers we were using before.
- removed cloudflare real_ip_header because using cloudflare for plex in 2023 will just result in buffering and bans.
- removed the HTTP error redirects to a root domain because this is a useless addition to the config.
- removed the PMS web server redirect to a root domain because this is a useless addition to the config.
